### PR TITLE
added descriptions text files to gold datasets

### DIFF
--- a/golds/nel/2022-dec-namedentity-wikipedialink/description.md
+++ b/golds/nel/2022-dec-namedentity-wikipedialink/description.md
@@ -1,0 +1,1 @@
+Named entity linking annotations over NewsHour files. Done by one annotator in the fall of 2022.

--- a/golds/nel/2022-dec-namedentity-wikipedialink/description.txt
+++ b/golds/nel/2022-dec-namedentity-wikipedialink/description.txt
@@ -1,0 +1,1 @@
+Named entity linking annotations over NewsHour files.

--- a/golds/ner/2022-jun-namedentity/description.md
+++ b/golds/ner/2022-jun-namedentity/description.md
@@ -1,0 +1,2 @@
+Annotation batch over 20 files from **The Newshour with Jim Lehrer**. Annotated
+in the summer of 2022 by one annotator.

--- a/golds/ner/2022-jun-namedentity/description.txt
+++ b/golds/ner/2022-jun-namedentity/description.txt
@@ -1,0 +1,1 @@
+NewsHour with Jim Lehrer

--- a/golds/ner/sample/description.txt
+++ b/golds/ner/sample/description.txt
@@ -1,0 +1,1 @@
+Sample annotations


### PR DESCRIPTION
I think we need to re-think if these files are well-fitted under `golds` directory (https://github.com/clamsproject/clams-aapb-annotations/issues/2#issuecomment-1523536739), but this PR is one of rebasing of #10, so keep the structure from that PR for now. 